### PR TITLE
Todayrecord

### DIFF
--- a/server/routes/admin/admin.controller.js
+++ b/server/routes/admin/admin.controller.js
@@ -179,7 +179,7 @@ router.put("/blk/info/edit", async (req, res) => {
 router.put("/blk/info/mh", async (req, res) => {
   try {
     const { body } = req;
-    const result = await AdminService.updateBlkMhInfo(body);
+    await AdminService.updateBlkMhInfo(body);
     return res.status(200).json({
       status: 200,
       message: "블럭 정보 수정 업데이트 성공",

--- a/src/component/admin/employee/EmployeeList.js
+++ b/src/component/admin/employee/EmployeeList.js
@@ -1,54 +1,76 @@
 import React, { useEffect, useState } from "react";
 import { List, Button } from "antd";
-import EmpRecordModal from "./EmpRecordModal";
-import useEmpRecordList from "../../../hooks/useEmpRecordList";
-import EmpWorkRecord from "../../emp/record/EmpWorkRecord";
-const EmployeeList = ({ empList }) => {
-  const [EMP_NO, setEmpNo] = useState(0);
-  const [EMP_NAME, setName] = useState("");
-  const [workRecordList, getMyWorkRecordList] = useEmpRecordList(EMP_NO);
+import useEmpRecordList from "hooks/useEmpRecordList";
+// import EmpWorkRecord from "emp/record/EmpWorkRecord";
+// import EmpRecordModal from "./EmpRecordModal";
 
-  useEffect(() => {
-    if (EMP_NO) getMyWorkRecordList(EMP_NO);
-  }, [EMP_NO, getMyWorkRecordList]);
+const EmployeeList = ({ empList }) => {
+  // const [EMP_NO, setEmpNo] = useState(0);
+  // const [EMP_NAME, setName] = useState("");
+  // const [workRecordList, getMyWorkRecordList] = useEmpRecordList(EMP_NO);
+  // useEffect(() => {
+  //   if (EMP_NO) getMyWorkRecordList(EMP_NO);
+  // }, [EMP_NO, getMyWorkRecordList]);
 
   return (
     <>
+      {/* FIXME: 사원 리스트 안나오는 이슈
       <EmpRecordModal title={"작업 내역"} EMP_NO={EMP_NO}>
         <EmpWorkRecord recordList={workRecordList} EMP_NAME={EMP_NAME} />
-      </EmpRecordModal>
+      </EmpRecordModal> */}
       {empList.length > 0 && (
         <List
           itemLayout="horizontal"
           dataSource={empList}
-          renderItem={(emp) => (
-            <List.Item>
-              <List.Item.Meta
-                title={
-                  <>
-                    <p>
-                      사원명 :<b>{emp.EMP_NAME}</b>{" "}
-                    </p>
-                    <p>
-                      사번 :<b>{emp.EMP_NO}</b>{" "}
-                    </p>
-                    <p>
-                      비밀번호 :<b>{emp.EMP_PW}</b>{" "}
-                    </p>
-                  </>
-                }
-                description={`${emp.EMP_NAME}님의 업무내역을 조회하시려면 버튼을 클릭하세요. `}
-              />
-              <Button
-                onClick={(e) => {
-                  setEmpNo(emp.EMP_NO);
-                  setName(emp.EMP_NAME);
-                }}
-              >
-                내역 보기
-              </Button>
-            </List.Item>
-          )}
+          renderItem={(emp) => {
+            if (emp.ADMIN) {
+              return (
+                <List.Item>
+                  <List.Item.Meta
+                    title={
+                      <>
+                        <p>
+                          관리자 :<b>{emp.EMP_NAME}</b>{" "}
+                        </p>
+                        <p>
+                          아이디 :<b>{emp.EMP_NO}</b>{" "}
+                        </p>
+                        <p>
+                          비밀번호 :<b>{emp.EMP_PW}</b>{" "}
+                        </p>
+                      </>
+                    }
+                  />
+                </List.Item>
+              );
+            }
+
+            let content;
+
+            if ("DAY_RECORD" in emp) {
+              const { work_type, INP_MH } = emp.DAY_RECORD;
+              content = `금일 시수 투입 여부 : O / 총 투입 시수:${INP_MH} / 작업:${work_type}`;
+            } else {
+              content = `금일 시수 투입 여부 : X`;
+            }
+
+            return (
+              <List.Item>
+                <List.Item.Meta
+                  title={
+                    <div>
+                      <span>사원명 : {emp.EMP_NAME} /</span>
+                      <span>사번(아이디) : {emp.EMP_NO} /</span>
+                      <span>비밀번호 : {emp.EMP_PW} </span>
+                      <p>
+                        <strong>{content}</strong>
+                      </p>
+                    </div>
+                  }
+                />
+              </List.Item>
+            );
+          }}
         />
       )}
     </>
@@ -56,3 +78,38 @@ const EmployeeList = ({ empList }) => {
 };
 
 export default EmployeeList;
+
+// {
+//   if(emp.ADMIN) {
+
+//   }
+
+//   return (
+//     <List.Item>
+//     <List.Item.Meta
+//       title={
+//         <>
+//           <p>
+//             사원명 :<b>{emp.EMP_NAME}</b>{" "}
+//           </p>
+//           <p>
+//             사번 :<b>{emp.EMP_NO}</b>{" "}
+//           </p>
+//           <p>
+//             비밀번호 :<b>{emp.EMP_PW}</b>{" "}
+//           </p>
+//         </>
+//       }
+//       description={`${emp.EMP_NAME}님의 업무내역을 조회하시려면 버튼을 클릭하세요. `}
+//     />
+//     {/* <Button
+//       onClick={(e) => {
+//         setEmpNo(emp.EMP_NO);
+//         setName(emp.EMP_NAME);
+//       }}
+//     >
+//       내역 보기
+//     </Button> */}
+//   </List.Item>
+//   )
+// }


### PR DESCRIPTION
**금일 업무 내역 조회 기능 ( admin ) #todayrecord**

- 문제 : 관리자 입장에서 사원이 금일에 시수를 입력했는지 확인 할 수 있는 화면 부재.
- 추가 기능 : 모든 사원이 업무 시수를 입력했는지 확인할 수 있는 화면이 필요.

![image](https://github.com/yeongi/work-manage/assets/40158148/c3b6a2d2-2389-498c-8d8f-0b3bc31f14e7)


- 업무 내역 조회 쿼리문 추가 → 사원 불러오기 리스트에 넣기

```tsx
	{
	EMP_NO: '10000',
	EMP_NAME: '김철수',
	EMP_PW: '1000',
	ADMIN: 0,
	DAY_RECORD: { work_type: '본작업', INP_MH: 24 }
},
```

- 금일 업무 내역이 있을 경우 응답

![image](https://github.com/yeongi/work-manage/assets/40158148/2d65e8e5-6781-4183-bc6a-3017dfe05f1f)

- 사원 목록 수정 완료